### PR TITLE
user experience testing 

### DIFF
--- a/lib/Lexicon.js
+++ b/lib/Lexicon.js
@@ -5,6 +5,8 @@ var UniqueSet = require("collections/set");
 var CORS = require("../../FieldDB/api/CORS").CORS;
 var Q = require("q");
 (function(exports) {
+
+  /* globals FieldDB */
   var escapeRegexCharacters = function(regex) {
     return regex.replace(/([()[{*+.$^\\|?])/g, '\\$1');
   };
@@ -15,7 +17,7 @@ var Q = require("q");
         this[property] = options[property];
       }
     }
-    this.igtBeforeCleaning = JSON.parse(JSON.stringify(options.igt));
+    this.fossil = JSON.parse(JSON.stringify(options.igt));
     Object.call(this);
   };
 
@@ -121,12 +123,12 @@ var Q = require("q");
         var successFunction = function(doc) {
           console.log(doc);
           doc.datumFields.map(function(datumField) {
-            if (self.igtBeforeCleaning[datumField.label] !== self.igt[datumField.label] && (new RegExp(escapeRegexCharacters(self.igtBeforeCleaning[datumField.label]), "i")).test(datumField.mask)) {
+            if (self.fossil[datumField.label] !== self.igt[datumField.label] && (new RegExp(escapeRegexCharacters(self.fossil[datumField.label]), "i")).test(datumField.mask)) {
               var change = {
                 before: datumField.mask + ""
               };
               // TODO this makes things lower case... because part of the map reduce seems to be doing that...
-              datumField.mask = datumField.mask.replace(new RegExp(escapeRegexCharacters(self.igtBeforeCleaning[datumField.label]), "ig"), self.igt[datumField.label]);
+              datumField.mask = datumField.mask.replace(new RegExp(escapeRegexCharacters(self.fossil[datumField.label]), "ig"), self.igt[datumField.label]);
               datumField.value = datumField.mask;
               change.after = datumField.mask;
               self.proposedChanges.push(change);
@@ -137,6 +139,9 @@ var Q = require("q");
         };
         var failFunction = function(reason) {
           console.log(reason);
+          if (FieldDB && FieldDB.FieldDBObject && typeof FieldDB.FieldDBObject.bug === "function"){
+            FieldDB.FieldDBObject.bug("There was a problem saving your changes. " + reason.reason); 
+          }
         };
 
         for (var idIndex = 0; idIndex < this.datumids.length; idIndex++) {
@@ -157,6 +162,7 @@ var Q = require("q");
     save: {
       value: function() {
         var deffered = Q.defer(),
+          self = this,
           promises = [];
 
         console.log("Saving cleaned datum...");
@@ -170,10 +176,27 @@ var Q = require("q");
           }));
         }
         Q.allSettled(promises).then(function(results) {
-          console.log("Saving results: ", results);
           deffered.resolve(results);
+          self.unsaved = true;
         });
         return deffered.promise;
+      }
+    },
+    unsaved: {
+      configurable: true,
+      get: function() {
+        if (this._unsaved) {
+          return this._unsaved;
+        }
+        if (this.fossil && !this.equals({
+          igt: this.fossil
+        })) {
+          this._unsaved = true;
+        }
+        return this._unsaved;
+      },
+      set: function(value) {
+        this._unsaved = value;
       }
     }
   });
@@ -215,6 +238,7 @@ var Q = require("q");
           fieldElement,
           fieldList,
           headword,
+          saveButton,
           contexts,
           field,
           classList;
@@ -249,7 +273,13 @@ var Q = require("q");
           headword = self.localDOM.createElement("span");
           headword.contentEditable = 'true';
           headword.classList.add("headword");
+          headword.setAttribute("title", "CLick to edit the headword of your lexical entry");
           listItemView.__data__.igt.headword = listItemView.__data__.igt.headword || listItemView.__data__.igt.morphemes ? listItemView.__data__.igt.morphemes : listItemView.__data__.igt.gloss;
+
+          saveButton = self.localDOM.createElement("button");
+          saveButton.classList.add("btn");
+          saveButton.setAttribute("title", "Click here to save");
+          saveButton.innerHTML = "Save";
 
           contexts = self.localDOM.createElement("span");
           contexts.classList.add("utteranceContext");
@@ -314,6 +344,7 @@ var Q = require("q");
 
           var component = {
             listItemView: listItemView,
+            saveButtonView: saveButton,
             headwordView: headword,
             contextsView: contexts,
             discussionView: discussion,
@@ -373,6 +404,12 @@ var Q = require("q");
             "headwordView.value": {
               "<-": "listItemView.__data__.igt.headword"
             },
+            "saveButtonView.innerHTML": {
+              "<-": "'Save '+listItemView.__data__.igt.headword"
+            },
+            "saveButtonView.classList.has('btn-danger')": {
+              "<-": "listItemView.__data__.unsaved"
+            },
             "discussionView.value": {
               "<-": "listItemView.__data__.igt.discussion"
             },
@@ -401,6 +438,7 @@ var Q = require("q");
           listItemView.appendChild(discussion);
           listItemView.appendChild(fieldList);
           listItemView.appendChild(contexts);
+          listItemView.appendChild(saveButton);
           listElement.appendChild(listItemView);
 
         });

--- a/lib/Lexicon.js
+++ b/lib/Lexicon.js
@@ -5,7 +5,9 @@ var UniqueSet = require("collections/set");
 var CORS = require("../../FieldDB/api/CORS").CORS;
 var Q = require("q");
 (function(exports) {
-
+  var escapeRegexCharacters = function(regex) {
+    return regex.replace(/([()[{*+.$^\\|?])/g, '\\$1');
+  };
 
   var LexiconNode = function(options) {
     for (var property in options) {
@@ -119,12 +121,12 @@ var Q = require("q");
         var successFunction = function(doc) {
           console.log(doc);
           doc.datumFields.map(function(datumField) {
-            if (self.igtBeforeCleaning[datumField.label] !== self.igt[datumField.label] && (new RegExp(self.igtBeforeCleaning[datumField.label], "i")).test(datumField.mask)) {
+            if (self.igtBeforeCleaning[datumField.label] !== self.igt[datumField.label] && (new RegExp(escapeRegexCharacters(self.igtBeforeCleaning[datumField.label]), "i")).test(datumField.mask)) {
               var change = {
                 before: datumField.mask + ""
               };
               // TODO this makes things lower case... because part of the map reduce seems to be doing that...
-              datumField.mask = datumField.mask.replace(new RegExp(self.igtBeforeCleaning[datumField.label], "ig"), self.igt[datumField.label]);
+              datumField.mask = datumField.mask.replace(new RegExp(escapeRegexCharacters(self.igtBeforeCleaning[datumField.label]), "ig"), self.igt[datumField.label]);
               datumField.value = datumField.mask;
               change.after = datumField.mask;
               self.proposedChanges.push(change);
@@ -217,7 +219,7 @@ var Q = require("q");
           field,
           classList;
 
-        var self =this;
+        var self = this;
         element = this.element;
         if (!element) {
           return;


### PR DESCRIPTION
I tested the browser with the corpus and found some things to improve:
1. Glosses with a ? were causing errors, so we fixed it to escape characters that would otherwise be interpreted as regex characters.
2. There was not clear indication when you need to save your lexical item (after changes), so we added a save button which will show if you have unsaved changes.
3. There was not clear indication when save failed, so we added a popup to warn the user.
